### PR TITLE
fix: correct doc url

### DIFF
--- a/rill-openrtb-prog-ads/dashboards/auction.yaml
+++ b/rill-openrtb-prog-ads/dashboards/auction.yaml
@@ -1,4 +1,4 @@
-# Visit https://docs.rilldata.com/references/project-files to learn more about Rill project files.
+# Visit https://docs.rilldata.com/reference/project-files to learn more about Rill project files.
 
 title: "Programmatic Ads Auction"
 model: "auction_data_model"

--- a/rill-openrtb-prog-ads/dashboards/bids.yaml
+++ b/rill-openrtb-prog-ads/dashboards/bids.yaml
@@ -1,4 +1,4 @@
-# Visit https://docs.rilldata.com/references/project-files to learn more about Rill project files.
+# Visit https://docs.rilldata.com/reference/project-files to learn more about Rill project files.
 
 title: "Programmatic Ads Bids"
 model: "bids_data_model"

--- a/rill-sec-formd/dashboards/offerings_issuers.yaml
+++ b/rill-sec-formd/dashboards/offerings_issuers.yaml
@@ -1,4 +1,4 @@
-# Visit https://docs.rilldata.com/references/project-files to learn more about Rill project files.
+# Visit https://docs.rilldata.com/reference/project-files to learn more about Rill project files.
 
 model: "offerings_issuers_model"
 default_time_range: ""


### PR DESCRIPTION
/references/ -> /reference/

New dashboards and the application code has the correct URL. This updates the demo dashboards.