### PR TITLE
Enable cloud_editing feature flag across example projects

### DIFF
--- a/clickhouse-s3-postgres/rill.yaml
+++ b/clickhouse-s3-postgres/rill.yaml
@@ -6,3 +6,4 @@ olap_connector: clickhouse
 
 features:
   clickhouseModeling: true
+  cloud_editing: true

--- a/connector-clickhouse/rill.yaml
+++ b/connector-clickhouse/rill.yaml
@@ -7,6 +7,7 @@ olap_connector: "clickhouse"
 
 features:
   clickhouseModeling: true
+  cloud_editing: true
 
 ignore_paths:
   - "/clickhouse_data"

--- a/embedding/rill-project/rill.yaml
+++ b/embedding/rill-project/rill.yaml
@@ -22,3 +22,4 @@ mock_users:
 features:
   dashboard_chat: true
   exports: "{{ not .user.embed }}"
+  cloud_editing: true

--- a/medicaid-provider-spending/rill.yaml
+++ b/medicaid-provider-spending/rill.yaml
@@ -10,3 +10,4 @@ olap_connector: duckdb
 
 features:
   cloudDataViewer: true
+  cloud_editing: true

--- a/rill-app-engagement/rill.yaml
+++ b/rill-app-engagement/rill.yaml
@@ -8,3 +8,4 @@ olap_connector: duckdb
 features:
   - cloudDataViewer
   - rillTime
+  - cloud_editing

--- a/rill-cost-monitoring/rill.yaml
+++ b/rill-cost-monitoring/rill.yaml
@@ -4,3 +4,6 @@ display_name: Infra Cost Margins Monitoring Demo
 description: This dashboard identifies opportunities to improve cloud infrastructure operations and to manage customer implementations. In this example, we’ve tied together a combination of cloud services, other hosting costs, and revenue metrics. Cost is the primary metric with insight into Revenue and Margins by Customer.
 
 olap_connector: duckdb
+
+features:
+  cloud_editing: true

--- a/rill-github-analytics/rill.yaml
+++ b/rill-github-analytics/rill.yaml
@@ -7,3 +7,4 @@ olap_connector: duckdb
 features:
   chat_charts: true
   dashboardChat: true
+  cloud_editing: true

--- a/rill-openrtb-prog-ads-canvas/rill.yaml
+++ b/rill-openrtb-prog-ads-canvas/rill.yaml
@@ -17,3 +17,4 @@ mock_users:
 
 features:
 - canvasDashboards
+- cloud_editing

--- a/rill-openrtb-prog-ads-clickhouse/rill.yaml
+++ b/rill-openrtb-prog-ads-clickhouse/rill.yaml
@@ -9,3 +9,4 @@ features:
   - clickhouseModeling
   - cloudDataViewer
   - rillTime
+  - cloud_editing

--- a/rill-openrtb-prog-ads/rill.yaml
+++ b/rill-openrtb-prog-ads/rill.yaml
@@ -20,3 +20,4 @@ models:
 
 features:
   chat_charts: true
+  cloud_editing: true

--- a/rill-partner-filtered-dashboards/rill.yaml
+++ b/rill-partner-filtered-dashboards/rill.yaml
@@ -4,6 +4,9 @@ display_name: Partner-Filtered Dashboards Demo
 
 olap_connector: duckdb
 
+features:
+  cloud_editing: true
+
 mock_users:
   - email: admin@rilldata.com
     admin: true

--- a/rill-sec-formd/rill.yaml
+++ b/rill-sec-formd/rill.yaml
@@ -7,3 +7,4 @@ olap_connector: duckdb
 features:
   - cloudDataViewer
   - rillTime
+  - cloud_editing


### PR DESCRIPTION
## Summary
- Add `cloud_editing: true` to every `rill.yaml` across the example projects, matching each file's existing `features:` style (map vs list form).
- For projects without an existing `features:` block (`rill-cost-monitoring`, `rill-partner-filtered-dashboards`), introduce a new map-form block.

## Test plan
- [ ] Open each example project in Rill and confirm cloud editing is enabled