### PR TITLE
Enable cloud_editing feature flag across demo example projects

### DIFF
--- a/connector-clickhouse/rill.yaml
+++ b/connector-clickhouse/rill.yaml
@@ -9,6 +9,7 @@ features:
   - cloudDataViewer
   - rillTime
   - dashboardChat
+  - cloud_editing
 
 ignore_paths:
   - "/clickhouse_data"

--- a/rill-app-engagement/rill.yaml
+++ b/rill-app-engagement/rill.yaml
@@ -7,3 +7,4 @@ features:
   - cloudDataViewer
   - rillTime
   - dashboardChat
+  - cloud_editing

--- a/rill-cost-monitoring/rill.yaml
+++ b/rill-cost-monitoring/rill.yaml
@@ -7,3 +7,4 @@ features:
   - cloudDataViewer
   - rillTime
   - chat
+  - cloud_editing

--- a/rill-embed/rill.yaml
+++ b/rill-embed/rill.yaml
@@ -16,3 +16,4 @@ features:
   - cloudDataViewer
   - rillTime
   - dashboardChat
+  - cloud_editing

--- a/rill-github-analytics/rill.yaml
+++ b/rill-github-analytics/rill.yaml
@@ -7,3 +7,4 @@ features:
   - cloudDataViewer
   - rillTime
   - dashboardChat
+  - cloud_editing

--- a/rill-openrtb-prog-ads-clickhouse/rill.yaml
+++ b/rill-openrtb-prog-ads-clickhouse/rill.yaml
@@ -9,3 +9,4 @@ features:
   - cloudDataViewer
   - rillTime
   - dashboardChat
+  - cloud_editing

--- a/rill-openrtb-prog-ads/rill.yaml
+++ b/rill-openrtb-prog-ads/rill.yaml
@@ -25,7 +25,8 @@ features:
   - dashboardChat
   - chat_charts
   - exportHeader
-    
+  - cloud_editing
+
 ai_instructions: |
   You are a data analyst, responding to questions from business users with precision, clarity, and concision.
 

--- a/rill-partner-filtered-dashboards/rill.yaml
+++ b/rill-partner-filtered-dashboards/rill.yaml
@@ -12,3 +12,4 @@ features:
   - cloudDataViewer
   - rillTime
   - dashboardChat
+  - cloud_editing

--- a/rill-sec-formd/rill.yaml
+++ b/rill-sec-formd/rill.yaml
@@ -6,3 +6,4 @@ features:
   - cloudDataViewer
   - rillTime
   - dashboardChat
+  - cloud_editing


### PR DESCRIPTION
## Summary
- Cherry-pick of [#44](https://github.com/rilldata/rill-examples/pull/44) onto the `demo` branch.
- Adds `- cloud_editing` to the existing list-form `features:` block in each project's `rill.yaml`.
- The `clickhouse-s3-postgres`, `embedding/rill-project`, and `medicaid-provider-spending` projects don't exist on `demo` and were skipped.

## Test plan
- [ ] Open each demo example project in Rill and confirm cloud editing is enabled